### PR TITLE
Avoid exit(1) without log data for CBMC and JBMC

### DIFF
--- a/cbmc.inc
+++ b/cbmc.inc
@@ -38,5 +38,8 @@ esac ; \
 \
 done \
 '
+  if [ ! -s $LOG.ok ] ; then
+    mv $LOG.latest $LOG.ok ; echo "EC=42" >> $LOG.ok
+  fi
   eval `tail -n 1 $LOG.ok`
 }

--- a/jbmc.inc
+++ b/jbmc.inc
@@ -38,5 +38,8 @@ esac ; \
 \
 done \
 '
+  if [ ! -s $LOG.ok ] ; then
+    mv $LOG.latest $LOG.ok ; echo "EC=42" >> $LOG.ok
+  fi
   eval `tail -n 1 $LOG.ok`
 }


### PR DESCRIPTION
Instead provide the fragment of the log produced up until the timeout happened.