### PR TITLE
Allow XML file to pass other flags to CBMC binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,24 @@ gprof --sum ./cbmc-binary *.gmon.out.*
 gprof ./cbmc-profiling gmon.sum > sum.profile
 rm gmon.out *.gmon.out.*
 ```
+
+#### Passing custom flags to CBMC
+
+The wrapper script hard-codes most of the flags that are passed in to
+CBMC. If you want to add more flags, for example to run experiments with
+different configurations of CBMC, you can pass those flags as a single
+value to the `--other-flags` flag of the wrapper script.
+
+When running `benchexec`, you will need to set this flag by writing it
+into the `cbmc.xml` file as an option, either at the global level or for
+one particular task:
+```xml
+...
+  <rundefinition name="sv-comp18"></rundefinition>
+
+  <option name="--graphml-witness">${logfile_path_abs}${inputfile_name}-witness.graphml</option>
+
+<!-- Add your custom options here: -->
+
+  <option name="--other-options"> --verbosity 10 --bogosity 15 --solve-halting-problem</option>
+```

--- a/cbmc.inc
+++ b/cbmc.inc
@@ -23,11 +23,11 @@ ulimit -v 15000000 ; \
 EC=42 ; \
 for c in 2 6 12 17 21 40 200 400 1025 2049 268435456 ; do \
 echo "Unwind: $c" > $LOG.latest ; \
-./cbmc-binary --graphml-witness $LOG.witness --unwind $c --stop-on-fail --object-bits $OBJ_BITS $PROPERTY $LOG.bin >> $LOG.latest 2>&1 ; \
+./cbmc-binary --other-options $OTHER_OPTIONS --graphml-witness $LOG.witness --unwind $c --stop-on-fail --object-bits $OBJ_BITS $PROPERTY $LOG.bin >> $LOG.latest 2>&1 ; \
 ec=$? ; \
 if [ $ec -eq 0 ] ; then \
 if ! tail -n 10 $LOG.latest | grep -q "^VERIFICATION SUCCESSFUL$" ; then ec=1 ; else \
-./cbmc-binary --unwinding-assertions --unwind $c --stop-on-fail --object-bits $OBJ_BITS $PROPERTY $LOG.bin > /dev/null 2>&1 || ec=42 ; \
+./cbmc-binary --other-options $OTHER_OPTIONS --unwinding-assertions --unwind $c --stop-on-fail --object-bits $OBJ_BITS $PROPERTY $LOG.bin > /dev/null 2>&1 || ec=42 ; \
 fi ; \
 fi ; \
 if [ $ec -eq 10 ] ; then \

--- a/tool-wrapper.inc
+++ b/tool-wrapper.inc
@@ -89,6 +89,7 @@ while [ -n "$1" ] ; do
     --32|--64) BIT_WIDTH="${1##--}" ; shift 1 ;;
     --propertyfile) PROP_FILE="$2" ; shift 2 ;;
     --graphml-witness) WITNESS_FILE="$2" ; shift 2 ;;
+    --other-options) OTHER_OPTIONS="$2" ; shift 2 ;;
     --version) $TOOL_BINARY --version ; exit 0 ;;
     *) BM="$1" ; shift 1 ;;
   esac
@@ -121,6 +122,7 @@ export BIT_WIDTH
 export BM
 export PROP
 export OBJ_BITS
+export OTHER_OPTIONS
 
 export GMON_OUT_PREFIX=`basename $BM`.gmon.out
 


### PR DESCRIPTION
The wrapper script now takes an `--other-options` option, whose value it
adds to the command line arguments to `./cbmc-binary`. This allows users
to write multiple benchexec XML files, each with a different set of
flags, and run SV-COMP experiments on each of them.