### PR TITLE
Dereference symlinks when copying files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ cbmc.zip: cbmc.inc tool-wrapper.inc $(CBMC)/LICENSE $(CBMC)/src/cbmc/cbmc $(CBMC
 	mkdir -p $(basename $@)
 	$(MAKE) cbmc-wrapper
 	mv cbmc-wrapper $(basename $@)/cbmc
-	cp $(CBMC)/LICENSE $(basename $@)/
-	cp $(CBMC)/src/cbmc/cbmc $(basename $@)/cbmc-binary
-	cp $(CBMC)/src/goto-cc/goto-cc $(basename $@)/
+	cp -L $(CBMC)/LICENSE $(basename $@)/
+	cp -L $(CBMC)/src/cbmc/cbmc $(basename $@)/cbmc-binary
+	cp -L $(CBMC)/src/goto-cc/goto-cc $(basename $@)/
 	chmod a+rX $(basename $@)/*
 	zip -r $@ $(basename $@)
 	cd $(basename $@) && rm cbmc cbmc-binary goto-cc LICENSE
@@ -34,9 +34,9 @@ cbmc.zip: cbmc.inc tool-wrapper.inc $(CBMC)/LICENSE $(CBMC)/src/cbmc/cbmc $(CBMC
 	mkdir -p $(basename $@)
 	$(MAKE) 2ls-wrapper
 	mv 2ls-wrapper $(basename $@)/2ls
-	cp $(2LS)/LICENSE $(basename $@)/
-	cp $(2LS)/src/2ls/2ls $(basename $@)/2ls-binary
-	cp $(2LS)/cbmc/src/goto-cc/goto-cc $(basename $@)/
+	cp -L $(2LS)/LICENSE $(basename $@)/
+	cp -L $(2LS)/src/2ls/2ls $(basename $@)/2ls-binary
+	cp -L $(2LS)/cbmc/src/goto-cc/goto-cc $(basename $@)/
 	chmod a+rX $(basename $@)/*
 	zip -r $@ $(basename $@)
 	cd $(basename $@) && rm 2ls 2ls-binary goto-cc LICENSE
@@ -46,9 +46,9 @@ jbmc.zip: jbmc.inc tool-wrapper.inc $(JBMC)/LICENSE $(JBMC)/jbmc/src/jbmc/jbmc $
 	mkdir -p $(basename $@)
 	$(MAKE) jbmc-wrapper
 	mv jbmc-wrapper $(basename $@)/jbmc
-	cp $(JBMC)/LICENSE $(basename $@)/
-	cp $(JBMC)/jbmc/src/jbmc/jbmc $(basename $@)/jbmc-binary
-	cp $(JBMC)/jbmc/lib/java-models-library/target/core-models.jar $(basename $@)/
+	cp -L $(JBMC)/LICENSE $(basename $@)/
+	cp -L $(JBMC)/jbmc/src/jbmc/jbmc $(basename $@)/jbmc-binary
+	cp -L $(JBMC)/jbmc/lib/java-models-library/target/core-models.jar $(basename $@)/
 	chmod a+rX $(basename $@)/*
 	zip -r $@ $(basename $@)
 	cd $(basename $@) && rm jbmc jbmc-binary core-models.jar LICENSE


### PR DESCRIPTION
Invocations to `cp` now include the -L flag, for users who build CBMC
out-of-tree and symlink cbmc/src/[tool-dir]/[tool] to the built binary.