### PR TITLE
Fix deref vs free detection

### DIFF
--- a/tool-wrapper.inc
+++ b/tool-wrapper.inc
@@ -59,14 +59,14 @@ parse_result()
     echo 'FALSE(valid-free)'
   elif tail -n 50 $LOG.ok | \
       grep -Eq "^(\[.*\] free argument has offset zero|[[:space:]]* free argument has offset zero$)" ; then
-    if tail -n 50 $LOG.ok | grep -Eq "^[[:space:]]+[a-zA-Z0-9_]+=INVALID" ; then
+    if tail -n 50 $LOG.ok | grep -Eq "^[[:space:]]+[a-zA-Z0-9_]+=INVALID-" ; then
       echo 'FALSE(valid-deref)'
     else
       echo 'FALSE(valid-free)'
     fi
   elif tail -n 50 $LOG.ok | \
       grep -Eq "^(\[.*\] |[[:space:]]*)free argument (is|must be) dynamic object" ; then
-    if tail -n 50 $LOG.ok | grep -Eq "^[[:space:]]+[a-zA-Z0-9_]+=INVALID" ; then
+    if tail -n 50 $LOG.ok | grep -Eq "^[[:space:]]+[a-zA-Z0-9_]+=INVALID-" ; then
       echo 'FALSE(valid-deref)'
     else
       echo 'FALSE(valid-free)'


### PR DESCRIPTION
Stupid hack that needs more testing

Examples to be correctly classified:
sv-benchmarks/c/list-ext-properties/list-ext_flag_false-unreach-call_false-valid-deref.i
sv-benchmarks/c/ldv-memsafety/memleaks_test3_false-valid-free.i