### PR TITLE
Also detect violations of lower bounds as invalid dereference

### DIFF
--- a/tool-wrapper.inc
+++ b/tool-wrapper.inc
@@ -52,7 +52,7 @@ parse_result()
       grep -Eq "^(\[.*\] |[[:space:]]*)dereference failure:" ; then
     echo 'FALSE(valid-deref)'
   elif tail -n 50 $LOG.ok | \
-      grep -Eq "^(\[.*\] |[[:space:]]*)array.* upper bound in " ; then
+      grep -Eq "^(\[.*\] |[[:space:]]*)array.* (lower|upper) bound in " ; then
     echo 'FALSE(valid-deref)'
   elif tail -n 50 $LOG.ok | \
       grep -Eq "^[[:space:]]+mem(cpy|set|move) (source region readable|destination region writeable)" ; then


### PR DESCRIPTION
This fixes the result reporting for loops/invert_string_false-valid-deref.c