### PR TITLE
Include creationtime in witness output

### DIFF
--- a/tool-wrapper.inc
+++ b/tool-wrapper.inc
@@ -101,7 +101,8 @@ process_graphml()
       <data key=\"specification\">$(<$PROP_FILE)<\/data>
       <data key=\"programfile\">$(echo ${BM[0]} | sed 's8/8\\/8g')<\/data>
       <data key=\"programhash\">$(sha1sum ${BM[0]} | awk '{print $1}')<\/data>
-      <data key=\"architecture\">${BIT_WIDTH}bit<\/data>\\Q/"
+      <data key=\"architecture\">${BIT_WIDTH}bit<\/data>
+      <data key=\"creationtime\">$(date -Iseconds)<\/data>\\Q/"
   fi
 }
 


### PR DESCRIPTION
This is strictly enforced by the witness linter.