### PR TITLE
Option for the valid-memcleanup property

### DIFF
--- a/tool-wrapper.inc
+++ b/tool-wrapper.inc
@@ -10,7 +10,7 @@ OPTIONS["unreach_call"]=""
 OPTIONS["termination"]=""
 OPTIONS["overflow"]="--signed-overflow-check --no-assertions"
 OPTIONS["memsafety"]="--pointer-check --memory-leak-check --bounds-check --no-assertions"
-OPTIONS["memcleanup"]="--pointer-check --memory-leak-check --bounds-check --no-assertions"
+OPTIONS["memcleanup"]="--pointer-check --memory-leak-check --memory-cleanup-check --bounds-check --no-assertions"
 
 parse_property_file()
 {


### PR DESCRIPTION
There is a difference between valid-memtrack and valid-memcleanup properties in SV-COMP. The difference is that memleaks occurring on `reach_error` should be reported only for the valid-memcleanup property.

This PR adds a new CLI option `--memory-cleanup-check`.

I added this option to the CBMC version that we use for 2LS [here](https://github.com/peterschrammel/cbmc/commit/fb7e3cd2d95603f0db457bf8f0047d7e01745e05). The idea is that memory leak assertions for abort-like functions are only added if this CLI option is used. 

This is implemented on a very old version of CBMC, though, so I'm not sure if it'll be possible to easily port it to the current version. If not, I can move this option into the 2LS wrapper script.