### PR TITLE
Use SHA-256 for program hash in witnesses

### DIFF
--- a/tool-wrapper.inc
+++ b/tool-wrapper.inc
@@ -100,7 +100,7 @@ process_graphml()
       <data key=\"producer\">$(echo $TOOL_NAME)<\/data>
       <data key=\"specification\">$(<$PROP_FILE)<\/data>
       <data key=\"programfile\">$(echo ${BM[0]} | sed 's8/8\\/8g')<\/data>
-      <data key=\"programhash\">$(sha1sum ${BM[0]} | awk '{print $1}')<\/data>
+      <data key=\"programhash\">$(sha256sum ${BM[0]} | awk '{print $1}')<\/data>
       <data key=\"architecture\">${BIT_WIDTH}bit<\/data>
       <data key=\"creationtime\">$(date -Iseconds)<\/data>\\Q/"
   fi


### PR DESCRIPTION
SHA-256 is required by [witness specification](229f3e8ce4e3b13e76b58dc42b5f9a4638bd79f9f3aa927499d1d902ea457152). It is now checked by the witness linter in SV-COMP so witnesses updated by this script are considered invalid.